### PR TITLE
hypothesis(mcp): add string-search exemption to gabb_structure guidance

### DIFF
--- a/.claude/skills/gabb/SKILL.md
+++ b/.claude/skills/gabb/SKILL.md
@@ -23,6 +23,8 @@ This saves tokens when you only need part of a large file.
 - The file is likely small (<100 lines)
 - You can answer from existing context
 - Files you've already seen structure for in this conversation
+- **You're searching for string literals, regex patterns, or error messages**
+  (gabb_structure shows symbols, not strings—use Grep directly)
 
 ## Supported Languages
 

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -23,6 +23,8 @@ This saves tokens when you only need part of a large file.
 - The file is likely small (<100 lines)
 - You can answer from existing context
 - Files you've already seen structure for in this conversation
+- **You're searching for string literals, regex patterns, or error messages**
+  (gabb_structure shows symbols, not strings—use Grep directly)
 
 ## Supported Languages
 


### PR DESCRIPTION
## Hypothesis

Relates to #106

We believe that adding explicit guidance to **skip gabb_structure for string/pattern search tasks** will reduce overhead on simple tasks without hurting complex navigation tasks.

**Rationale**: `gabb_structure` returns symbols (functions, classes, structs) but NOT string literals. For tasks that involve finding regex patterns, error messages, or config values, direct `Grep` is optimal. The current guidance doesn't make this distinction clear.

## Implementation

Added to the "Skip when:" section in `assets/SKILL.md`:

```markdown
- **You're searching for string literals, regex patterns, or error messages**
  (gabb_structure shows symbols, not strings—use Grep directly)
```

Also updated `.claude/skills/gabb/SKILL.md` (local copy).

## Benchmark Plan

- [ ] Target task: `astropy__astropy-14365` (20 runs) — expect -20-30% time
- [ ] Control task: `astropy__astropy-7746` (20 runs, if target improves) — expect no regression
- [ ] SWE-bench lite (10 runs each, if control unaffected)

## Results

*To be added as comments after benchmark runs*

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)