### PR TITLE
hypothesis(mcp): add task complexity assessment to prevent over-exploration

### DIFF
--- a/.claude/skills/gabb/SKILL.md
+++ b/.claude/skills/gabb/SKILL.md
@@ -10,7 +10,10 @@ allowed-tools: mcp__gabb__gabb_structure, Edit, Write, Bash, Read, Glob
 
 ## When to Use `gabb_structure`
 
-Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
+**First:** Assess if exploration is needed (see MCP instructions).
+For trivial tasks with obvious targets, go directly to the file.
+
+**If exploring:** Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
 This saves tokens when you only need part of a large file.
 
 **Recommended for:**

--- a/assets/MCP_INSTRUCTIONS.md
+++ b/assets/MCP_INSTRUCTIONS.md
@@ -2,6 +2,25 @@
 
 Code indexing server providing lightweight file structure previews via SQLite index.
 
+## Task Complexity Assessment
+
+Before using gabb exploration tools, assess whether exploration is needed:
+
+**Go direct (skip exploration) when:**
+- Task names a specific file or function (e.g., "fix bug in utils.py")
+- Change is localized (e.g., "add parameter to X", "rename Y to Z")
+- You can identify the exact target from the task description
+- Task is a simple fix with obvious location
+
+**Explore when:**
+- Task requires understanding system architecture
+- You need to find where something is implemented
+- Change affects multiple components or has unclear scope
+- You're unfamiliar with the codebase structure
+
+⚠️ **Over-exploration costs time.** A trivial task that could be solved in 15s
+can take 60s+ with unnecessary exploration. Match exploration depth to task complexity.
+
 ## Pre-Read Check for Code Files (Recommended)
 
 For large or unfamiliar code files, consider calling `gabb_structure` first to see the layout.

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -10,7 +10,10 @@ allowed-tools: mcp__gabb__gabb_structure, Edit, Write, Bash, Read, Glob
 
 ## When to Use `gabb_structure`
 
-Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
+**First:** Assess if exploration is needed (see MCP instructions).
+For trivial tasks with obvious targets, go directly to the file.
+
+**If exploring:** Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
 This saves tokens when you only need part of a large file.
 
 **Recommended for:**


### PR DESCRIPTION
## Hypothesis

Relates to #109

Adding **task complexity assessment** guidance to MCP_INSTRUCTIONS.md will reduce over-exploration on trivial tasks while maintaining benefits on complex tasks, because the current guidance tells Claude *how* to use gabb tools but not *whether* exploration is warranted for the task at hand.

## Evidence from Benchmark (2026-01-06)

The regression on django__django-11620 showed:
- **Control:** 13-26s, 1-2 Read calls (direct to file)
- **Gabb:** 51-72s, 6-14 Bash, 6-9 Grep, 7-8 Read (massive over-exploration)

**Root cause:** The task was trivial (localized fix), but Gabb condition triggered exploration mode. Control went direct because it had no exploration tools encouraging exploration.

## Implementation

1. **MCP_INSTRUCTIONS.md** — Added "Task Complexity Assessment" section at top with:
   - Clear "Go direct" criteria (task names specific file, localized change, obvious target)
   - Clear "Explore when" criteria (architecture understanding, unclear scope, unfamiliar codebase)
   - ⚠️ warning about over-exploration costs

2. **SKILL.md** (both assets/ and .claude/skills/gabb/) — Added brief reference:
   - "First: Assess if exploration is needed"
   - Points to MCP instructions for full criteria

## Benchmark Plan

- [ ] Target task: `django__django-11620` (20 runs) — the regression task
- [ ] Control task: `astropy__astropy-14995` (20 runs) — best performing task, should maintain improvement
- [ ] Wider task set (if control unaffected)

## Expected Results

| Metric | Target |
|--------|--------|
| django-11620 regression | Eliminate or significantly reduce |
| Complex task performance | Maintain current improvements |
| Overall time savings | Maintain or improve 13.8% |

## Results

*To be added after benchmark runs*

🤖 Generated with [Claude Code](https://claude.com/claude-code)