### PR TITLE
hypothesis(mcp): replace binary explore/skip with progressive exploration ladder

### DIFF
--- a/assets/MCP_INSTRUCTIONS.md
+++ b/assets/MCP_INSTRUCTIONS.md
@@ -2,24 +2,35 @@
 
 Code indexing server providing lightweight file structure previews via SQLite index.
 
-## Task Complexity Assessment
+## Exploration Ladder
 
-Before using gabb exploration tools, assess whether exploration is needed:
+Match exploration depth to **actual** difficulty, not predicted difficulty.
+Start simple and escalate only when needed.
 
-**Go direct (skip exploration) when:**
-- Task names a specific file or function (e.g., "fix bug in utils.py")
-- Change is localized (e.g., "add parameter to X", "rename Y to Z")
-- You can identify the exact target from the task description
-- Task is a simple fix with obvious location
+### Level 1 - Direct (try first)
+- Go directly to the most likely file based on task description
+- If you find what you need, stop here
+- Use when: task names a specific file/function, change is localized, obvious location
 
-**Explore when:**
-- Task requires understanding system architecture
-- You need to find where something is implemented
-- Change affects multiple components or has unclear scope
-- You're unfamiliar with the codebase structure
+### Level 2 - Targeted Search (if Level 1 insufficient)
+- Use Grep for specific symbols/patterns mentioned in the task
+- Read 1-2 additional files identified by search
+- Use when: direct attempt didn't find the target, need to locate a symbol
+
+### Level 3 - Structure Overview (if still stuck)
+- Use gabb_structure on candidate files to understand layout
+- Read targeted sections based on structure
+- Use when: file is large and you need to find the right section
+
+### Level 4 - Full Exploration (only for genuinely complex tasks)
+- Use Task agents for systematic codebase exploration
+- Use when: architectural questions, multi-component changes, truly unknown territory
+
+**Key principle:** Start at Level 1 and escalate only when needed.
+Don't predict difficulty—discover it.
 
 ⚠️ **Over-exploration costs time.** A trivial task that could be solved in 15s
-can take 60s+ with unnecessary exploration. Match exploration depth to task complexity.
+can take 60s+ with unnecessary exploration.
 
 ## Pre-Read Check for Code Files (Recommended)
 

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -10,11 +10,12 @@ allowed-tools: mcp__gabb__gabb_structure, Edit, Write, Bash, Read, Glob
 
 ## When to Use `gabb_structure`
 
-**First:** Assess if exploration is needed (see MCP instructions).
-For trivial tasks with obvious targets, go directly to the file.
+**Use the Exploration Ladder** (see MCP instructions). `gabb_structure` belongs at **Level 3**—use it when:
+- Level 1 (direct read) and Level 2 (targeted grep) didn't find what you need
+- You're reading a large file and need to find the right section
+- You want to understand a file's layout before reading specific parts
 
-**If exploring:** Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
-This saves tokens when you only need part of a large file.
+Don't start with gabb_structure. Start simple, escalate when needed.
 
 **Recommended for:**
 - Large files (>100 lines) where you only need part


### PR DESCRIPTION
## Hypothesis

Relates to #111

Replace the binary "go direct or explore" decision from #109 with a **progressive exploration ladder** that matches exploration depth to actual difficulty discovered during the task, not predicted difficulty.

The current approach asks Claude to decide upfront: explore or go direct. This creates a cliff:
- Tasks classified as "simple" → no exploration at all
- Tasks classified as "complex" → full exploration

But many tasks fall in the middle. A progressive approach:
1. Starts with minimal effort (direct read of most likely file)
2. Escalates only when stuck
3. Uses heavier exploration tools only when lighter ones fail

## Implementation

Updated `assets/MCP_INSTRUCTIONS.md` with a 4-level exploration ladder:
- **Level 1 - Direct:** Go directly to the most likely file
- **Level 2 - Targeted Search:** Use Grep for specific symbols/patterns
- **Level 3 - Structure Overview:** Use gabb_structure on candidate files
- **Level 4 - Full Exploration:** Use Task agents for systematic exploration

Key principle: Start at Level 1 and escalate only when needed. Don't predict difficulty—discover it.

Updated `assets/SKILL.md` to position gabb_structure as Level 3, not a default first step.

## Benchmark Plan

- [ ] Target task: django__django-11283 (30 runs) - medium complexity, should benefit from faster initial attempts
- [ ] Control task: astropy__astropy-14995 (20 runs, if target improves) - complex task that legitimately needs exploration
- [ ] Wider task set (if control unaffected)

## Expected Improvement

| Metric | Expected Change | Rationale |
|--------|-----------------|-----------|
| Time on medium-complexity tasks | -15-20% | Faster initial attempts, escalation only when needed |
| Time on simple tasks | Maintain gains from #109 | Still starts direct |
| Time on complex tasks | No regression | Will escalate to full exploration when needed |
| Success rate | Maintain or improve | Fewer timeouts from unnecessary exploration |

## Results

*Added as comments after each benchmark run*

🤖 Generated with [Claude Code](https://claude.com/claude-code)