### PR TITLE
hypothesis(mcp): add anti-patterns to prevent over-exploration

### DIFF
--- a/assets/MCP_INSTRUCTIONS.md
+++ b/assets/MCP_INSTRUCTIONS.md
@@ -21,6 +21,30 @@ Before using gabb exploration tools, assess whether exploration is needed:
 ⚠️ **Over-exploration costs time.** A trivial task that could be solved in 15s
 can take 60s+ with unnecessary exploration. Match exploration depth to task complexity.
 
+## Anti-Patterns to Avoid
+
+❌ **Over-exploration on obvious targets:**
+
+```
+Task: "Fix Http404 handling in technical_404_response in debug views"
+
+BAD (60s): Grep "Http404" → Glob "*debug*" → Read 5 wrong files → finally find it
+GOOD (15s): Read django/views/debug.py → Done (task named the file)
+```
+
+**Key insight:** If the task names specific files or functions, trust that information. Don't verify what's already stated.
+
+❌ **Task agent for simple lookups:**
+
+```
+Task: "Find where UserSerializer is defined"
+
+BAD: Launch Task agent to "explore serializers"
+GOOD: Grep "class UserSerializer" → Read the match
+```
+
+**Key insight:** Direct tool calls beat exploration agents for specific symbol lookups.
+
 ## Pre-Read Check for Code Files (Recommended)
 
 For large or unfamiliar code files, consider calling `gabb_structure` first to see the layout.


### PR DESCRIPTION
## Hypothesis

Relates to #113

Adding concrete negative examples (anti-patterns) showing what NOT to do will help Claude recognize and avoid over-exploration patterns, because language models learn effectively from contrastive examples that demonstrate both correct and incorrect behavior.

## Implementation

Added "Anti-Patterns to Avoid" section to `assets/MCP_INSTRUCTIONS.md` after the Task Complexity Assessment section. Includes two anti-patterns:

1. **Over-exploration on obvious targets** - When task names specific files/functions, trust that information instead of verifying with Grep/Glob
2. **Task agent for simple lookups** - Direct tool calls beat exploration agents for specific symbol lookups

## Benchmark Plan

- [ ] Target task: django__django-11620 (20-30 runs) - task explicitly names `technical_404_response` and `debug`
- [ ] Control task: astropy__astropy-7746 (20-30 runs, if target improves) - complex task requiring legitimate exploration
- [ ] Wider task set (if control unaffected)

## Expected Improvement

- Target task time: -15-25% (from ~60s to ~45s or less)
- Over-exploration incidents: -50%
- Control task: No regression

## Results

_To be added as comments after each benchmark run_