### PR TITLE
hypothesis(mcp): reframe decision flow as parallel-first

### DIFF
--- a/.claude/skills/gabb/SKILL.md
+++ b/.claude/skills/gabb/SKILL.md
@@ -8,14 +8,31 @@ allowed-tools: mcp__gabb__gabb_structure, mcp__gabb__gabb_symbol, Edit, Write, B
 
 # Gabb Code Navigation
 
-## Search Strategy Decision Flow
+## Search Strategy (Parallel-First)
 
-When you need to find code, follow this order:
+When the target location isn't obvious, run MULTIPLE searches in parallel:
 
-1. **Task names specific file/function?** → Read directly (skip exploration)
-2. **Looking for a code construct by name?** → `gabb_symbol`
-3. **Looking for text content (strings, error messages)?** → Grep
-4. **Need to understand file layout?** → `gabb_structure`
+**Combine in ONE turn:**
+- `gabb_symbol` for likely function/class names
+- `Grep` for error messages, string literals, or text patterns
+- `Glob` for filename patterns (if file location is hinted)
+
+**Example:** Task mentions "fix the IsNull lookup validation"
+→ Call `gabb_symbol(name="IsNull")` AND `Grep(pattern="IsNull")` in same turn
+→ Don't wait for one to finish before trying the other
+
+**After finding a location:** Immediately Read the file in the SAME response.
+Don't make it a separate turn.
+
+**Only go sequential when:**
+- First search definitively found the target (no need for more)
+- You need the result of tool A to know what to search for with tool B
+
+**Efficiency target:** Aim for ≤3 turns per task. Each turn adds context tokens.
+
+**Skip exploration entirely when:**
+- Task names a specific file/function → Read directly
+- Change is localized with obvious target
 
 ## `gabb_symbol` - Workspace Symbol Search
 

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -8,14 +8,31 @@ allowed-tools: mcp__gabb__gabb_structure, mcp__gabb__gabb_symbol, Edit, Write, B
 
 # Gabb Code Navigation
 
-## Search Strategy Decision Flow
+## Search Strategy (Parallel-First)
 
-When you need to find code, follow this order:
+When the target location isn't obvious, run MULTIPLE searches in parallel:
 
-1. **Task names specific file/function?** → Read directly (skip exploration)
-2. **Looking for a code construct by name?** → `gabb_symbol`
-3. **Looking for text content (strings, error messages)?** → Grep
-4. **Need to understand file layout?** → `gabb_structure`
+**Combine in ONE turn:**
+- `gabb_symbol` for likely function/class names
+- `Grep` for error messages, string literals, or text patterns
+- `Glob` for filename patterns (if file location is hinted)
+
+**Example:** Task mentions "fix the IsNull lookup validation"
+→ Call `gabb_symbol(name="IsNull")` AND `Grep(pattern="IsNull")` in same turn
+→ Don't wait for one to finish before trying the other
+
+**After finding a location:** Immediately Read the file in the SAME response.
+Don't make it a separate turn.
+
+**Only go sequential when:**
+- First search definitively found the target (no need for more)
+- You need the result of tool A to know what to search for with tool B
+
+**Efficiency target:** Aim for ≤3 turns per task. Each turn adds context tokens.
+
+**Skip exploration entirely when:**
+- Task names a specific file/function → Read directly
+- Change is localized with obvious target
 
 ## `gabb_symbol` - Workspace Symbol Search
 


### PR DESCRIPTION
## Hypothesis

Relates to #120

We believe that **replacing the sequential "follow this order" decision flow with parallel-first framing AND explicit guidance to combine tool calls in one turn** will reduce token cost by 15-25% while maintaining time improvements.

### Root Cause Being Addressed

The current SKILL.md presents a sequential decision flow:
```
When you need to find code, follow this order:
1. Task names specific file? → Read directly
2. Looking for code construct? → gabb_symbol
...
```

This "follow this order" language creates a sequential mental model. Claude interprets it as "try option 1, wait for result, then try option 2" rather than speculatively trying multiple approaches in parallel.

**Evidence:** Analysis of 40 SWE-bench lite tasks showed:
- Tool calls/turn: 4.47 (control) vs 2.22 (gabb) - 50% less parallel
- Turn count correlation with token difference: r=0.939

## Implementation

Replaced the sequential numbered decision flow with parallel-first guidance:

1. **Removed** the sequential "follow this order" framing
2. **Added** explicit parallel-first guidance with example
3. **Provided** mechanical guidance for combining tool calls
4. **Set** efficiency target of ≤3 turns per task

## Benchmark Plan

- [ ] Target task: django__django-11019 (20 runs) - currently shows 5 turns vs 2 turns in control
- [ ] Control task: django__django-12470 (20 runs, if target improves) - already achieves -45% tokens
- [ ] Wider task set (if control unaffected)

## Success Criteria

1. Target task reduces turns from 5 to ≤3
2. Target task reduces token increase from +97% to ≤+20%
3. Control task maintains token savings
4. Tool calls per turn increases from 2.22 toward 3.5+

## Results

_To be added after benchmark runs_