### PR TITLE
hypothesis(mcp): remove tool guidance from SKILL.md to leverage Task/Explore parallelization

### DIFF
--- a/.claude/skills/gabb/SKILL.md
+++ b/.claude/skills/gabb/SKILL.md
@@ -6,56 +6,21 @@ description: |
 allowed-tools: mcp__gabb__gabb_structure, mcp__gabb__gabb_symbol, Edit, Write, Bash, Read, Glob
 ---
 
-# Gabb Code Navigation
+# Gabb MCP Server
 
-## Search Strategy Decision Flow
+Code indexing server providing semantic symbol search and file structure previews.
 
-When you need to find code, follow this order:
+## Available Tools
 
-1. **Task names specific file/function?** → Read directly (skip exploration)
-2. **Looking for a code construct by name?** → `gabb_symbol`
-3. **Looking for text content (strings, error messages)?** → Grep
-4. **Need to understand file layout?** → `gabb_structure`
+### `gabb_symbol` - Symbol Search
 
-## `gabb_symbol` - Workspace Symbol Search
+Search for functions, classes, methods by name across the workspace.
+Returns: symbol kind, name, file:line:col
 
-Search for symbols (functions, classes, methods) by name across the workspace.
+### `gabb_structure` - File Structure
 
-**When to use:**
-- Task mentions a function/class/method name to find or fix
-- You need to find where something is defined
-- Grep would return too many false positives
-
-**Example:**
-```
-gabb_symbol name="update_proxy_model_permissions"
-→ function update_proxy_model_permissions [prod] migrations/0011_update_proxy_permissions.py:5:1
-```
-
-**Use Grep instead when:**
-- Searching for error messages or string literals
-- Looking for text patterns, not code identifiers
-
-## `gabb_structure` - File Layout Preview
-
-**First:** Assess if exploration is needed (see MCP instructions).
-For trivial tasks with obvious targets, go directly to the file.
-
-**If exploring:** Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
-This saves tokens when you only need part of a large file.
-
-**Recommended for:**
-- Large files (>100 lines) where you only need part
-- Unfamiliar codebases where you're exploring
-- Files you'll read multiple times
-
-**Skip when:**
-- You already know exactly what you're looking for
-- The file is likely small (<100 lines)
-- You can answer from existing context
-- Files you've already seen structure for in this conversation
-- **You're searching for string literals, regex patterns, or error messages**
-  (gabb_structure shows symbols, not strings—use Grep directly)
+Get a lightweight overview of a file's symbols before reading it.
+Returns: symbol names, kinds, line numbers (NOT source code)
 
 ## Supported Languages
 
@@ -67,40 +32,3 @@ This saves tokens when you only need part of a large file.
 | Go         | `.go`                                  |
 | Kotlin     | `.kt`, `.kts`                          |
 | C++        | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hh`   |
-
-## Usage Patterns
-
-### Symbol Search
-```
-gabb_symbol name="MyClass"
-→ class MyClass [prod] src/models.py:45:1
-```
-
-### File Structure Preview
-```
-1. gabb_structure file="src/large_file.rs"
-   → Returns symbol names, kinds, line numbers (NO source code)
-
-2. Read file_path="src/large_file.rs" offset=150 limit=50
-   → Read only the section you need
-```
-
-## What `gabb_structure` Output Looks Like
-
-```
-/path/to/file.rs:450
-Summary: 15 functions, 3 structs | 450 lines
-Key types: MyStruct (10 methods)
-
-MyStruct st 10
- new fn 12
- process fn 17
-helper fn 30
-main fn 50
-```
-
-The output shows:
-- File path and line count
-- Summary stats (function count, struct count, line count)
-- Key types with method counts
-- Compact symbol tree: `name kind_abbrev line` with single-space indent for children

--- a/assets/SKILL.md
+++ b/assets/SKILL.md
@@ -6,56 +6,21 @@ description: |
 allowed-tools: mcp__gabb__gabb_structure, mcp__gabb__gabb_symbol, Edit, Write, Bash, Read, Glob
 ---
 
-# Gabb Code Navigation
+# Gabb MCP Server
 
-## Search Strategy Decision Flow
+Code indexing server providing semantic symbol search and file structure previews.
 
-When you need to find code, follow this order:
+## Available Tools
 
-1. **Task names specific file/function?** → Read directly (skip exploration)
-2. **Looking for a code construct by name?** → `gabb_symbol`
-3. **Looking for text content (strings, error messages)?** → Grep
-4. **Need to understand file layout?** → `gabb_structure`
+### `gabb_symbol` - Symbol Search
 
-## `gabb_symbol` - Workspace Symbol Search
+Search for functions, classes, methods by name across the workspace.
+Returns: symbol kind, name, file:line:col
 
-Search for symbols (functions, classes, methods) by name across the workspace.
+### `gabb_structure` - File Structure
 
-**When to use:**
-- Task mentions a function/class/method name to find or fix
-- You need to find where something is defined
-- Grep would return too many false positives
-
-**Example:**
-```
-gabb_symbol name="update_proxy_model_permissions"
-→ function update_proxy_model_permissions [prod] migrations/0011_update_proxy_permissions.py:5:1
-```
-
-**Use Grep instead when:**
-- Searching for error messages or string literals
-- Looking for text patterns, not code identifiers
-
-## `gabb_structure` - File Layout Preview
-
-**First:** Assess if exploration is needed (see MCP instructions).
-For trivial tasks with obvious targets, go directly to the file.
-
-**If exploring:** Before reading large or unfamiliar code files, consider using `gabb_structure` to preview the layout.
-This saves tokens when you only need part of a large file.
-
-**Recommended for:**
-- Large files (>100 lines) where you only need part
-- Unfamiliar codebases where you're exploring
-- Files you'll read multiple times
-
-**Skip when:**
-- You already know exactly what you're looking for
-- The file is likely small (<100 lines)
-- You can answer from existing context
-- Files you've already seen structure for in this conversation
-- **You're searching for string literals, regex patterns, or error messages**
-  (gabb_structure shows symbols, not strings—use Grep directly)
+Get a lightweight overview of a file's symbols before reading it.
+Returns: symbol names, kinds, line numbers (NOT source code)
 
 ## Supported Languages
 
@@ -67,40 +32,3 @@ This saves tokens when you only need part of a large file.
 | Go         | `.go`                                  |
 | Kotlin     | `.kt`, `.kts`                          |
 | C++        | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hh`   |
-
-## Usage Patterns
-
-### Symbol Search
-```
-gabb_symbol name="MyClass"
-→ class MyClass [prod] src/models.py:45:1
-```
-
-### File Structure Preview
-```
-1. gabb_structure file="src/large_file.rs"
-   → Returns symbol names, kinds, line numbers (NO source code)
-
-2. Read file_path="src/large_file.rs" offset=150 limit=50
-   → Read only the section you need
-```
-
-## What `gabb_structure` Output Looks Like
-
-```
-/path/to/file.rs:450
-Summary: 15 functions, 3 structs | 450 lines
-Key types: MyStruct (10 methods)
-
-MyStruct st 10
- new fn 12
- process fn 17
-helper fn 30
-main fn 50
-```
-
-The output shows:
-- File path and line count
-- Summary stats (function count, struct count, line count)
-- Key types with method counts
-- Compact symbol tree: `name kind_abbrev line` with single-space indent for children


### PR DESCRIPTION
## Hypothesis

Relates to #126

We believe that **removing tool guidance from SKILL.md** will improve token efficiency by 40-60% while maintaining time improvements, because the current guidance causes Claude to bypass the Task/Explore agent's internal parallelization.

### Background

Analysis of issue #120's benchmark revealed that:

1. **Task/Explore agent parallelizes internally**: When Claude uses `Task` with `subagent_type="Explore"`, the sub-agent makes multiple parallel tool calls in a single turn.

2. **SKILL.md overrides this pattern**: The detailed gabb SKILL.md encourages direct tool calls (`gabb_symbol`, `gabb_structure`), which bypasses the Task/Explore mechanism.

3. **Direct tool calls serialize**: Claude makes 1 tool call per turn when calling tools directly (0.98 tools/turn with gabb vs 5.17 tools/turn with control).

## Implementation

This implements **Option A** from the hypothesis - a minimal SKILL.md that removes all "when to use" guidance and decision flow instructions.

The minimal SKILL.md keeps only:
- Basic tool descriptions (what they do, not when to use them)
- Supported languages table

**Changes:** 162 lines removed, 18 lines added

## Benchmark Plan

- [ ] Target task: django__django-11019 (20 runs)
- [ ] Control task: django__django-12470 (20 runs, if target improves)
- [ ] Wider task set (if control unaffected)

## Success Criteria

From issue #126:
1. Tools/turn increases from 0.98 to ≥3.0
2. Turns decrease from 4.2 to ≤3
3. Token increase drops from +70% to ≤+20%
4. Time savings maintained at ≥40%

## Results

*To be added as comments after benchmark runs*