### PR TITLE
skill-review: improve gabb-code-navigation skill

### DIFF
--- a/.claude/skills/gabb/SKILL.md
+++ b/.claude/skills/gabb/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: gabb-code-navigation
-description: |
-  Teaches when to use gabb_structure for efficient file exploration.
-  Use gabb_structure before reading large files in supported languages.
+description: >
+  Navigate and explore codebases using symbol search and file structure preview via gabb MCP tools. Finds functions, classes, and methods by name across workspaces, previews large file layouts before reading. Use when the user says 'find function', 'find class', 'explore file', 'symbol search', 'code structure', 'where is defined', or needs to navigate unfamiliar code.
 allowed-tools: mcp__gabb__gabb_structure, mcp__gabb__gabb_symbol, Edit, Write, Bash, Read, Glob
 ---
 


### PR DESCRIPTION
hey @gabb-software, thanks for building the gabb CLI tools. kudos for the repo! just starred it.

ran your gabb-code-navigation skill through some evals and noticed a few things that were pretty quick to improve (moving from `~57%` to `~96%` agent performance):

- expanded description with capability statement + trigger terms like _find function_, _symbol search_, _code structure_

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `3` skills, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.